### PR TITLE
fix(UI): slider component position on remove liquidity page

### DIFF
--- a/src/components/pages/remove-liquidity-page/components/Slider/index.module.css
+++ b/src/components/pages/remove-liquidity-page/components/Slider/index.module.css
@@ -34,6 +34,7 @@
   -webkit-appearance: none;
   appearance: none;
   width: 20px;
+  margin-left: var(--thumb-margin, 0);
   height: 20px;
   background: radial-gradient(
     circle at center,

--- a/src/components/pages/remove-liquidity-page/components/Slider/index.tsx
+++ b/src/components/pages/remove-liquidity-page/components/Slider/index.tsx
@@ -4,13 +4,8 @@ import clsx from "clsx";
 
 const STEPS = ["0%", "25%", "50%", "75%", "100%"];
 
-const thumbMargin = {
-  0: "-6px",
-  25: "-3px",
-  50: "0px",
-  75: "3px",
-  100: "6px",
-};
+const getThumbMargin = (percentage: number) =>
+  `${(percentage - 50) * (6 / 50)}px`;
 
 const Slider = ({
   value,
@@ -23,7 +18,7 @@ const Slider = ({
     onChange(Number(event.target.value));
     event.target.style.setProperty(
       "--thumb-margin",
-      thumbMargin[event.target.value as unknown as keyof typeof thumbMargin],
+      getThumbMargin(Number(event.target.value)),
     );
   };
 

--- a/src/components/pages/remove-liquidity-page/components/Slider/index.tsx
+++ b/src/components/pages/remove-liquidity-page/components/Slider/index.tsx
@@ -4,6 +4,14 @@ import clsx from "clsx";
 
 const STEPS = ["0%", "25%", "50%", "75%", "100%"];
 
+const thumbMargin = {
+  0: "-6px",
+  25: "-3px",
+  50: "0px",
+  75: "3px",
+  100: "6px",
+};
+
 const Slider = ({
   value,
   onChange,
@@ -13,6 +21,10 @@ const Slider = ({
 }) => {
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     onChange(Number(event.target.value));
+    event.target.style.setProperty(
+      "--thumb-margin",
+      thumbMargin[event.target.value as unknown as keyof typeof thumbMargin],
+    );
   };
 
   const getIsSelectedDot = (dot: string) =>


### PR DESCRIPTION
Close [131](https://github.com/athulp8457/mira-amm-web/issues/131)

### Solution

Currently, the position of the slider thumb is hardcoded. If more points are added in the future, the flow should be updated accordingly. The current CSS handling is a temporary solution and should be improved. Ideally, we should either enhance the custom CSS for better maintainability or consider using a well-supported npm package if handling it manually becomes complex.
