### PR TITLE
fix: adjust SVG viewBox to prevent TM mark from being clipped

### DIFF
--- a/libs/web/src/components/icons/Logo/LogoIcon.tsx
+++ b/libs/web/src/components/icons/Logo/LogoIcon.tsx
@@ -1,9 +1,9 @@
 const LogoIcon = () => {
   return (
     <svg
-      width="182"
+      width="184"
       height="28"
-      viewBox="0 0 182 28"
+      viewBox="0 0 184 28"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >


### PR DESCRIPTION
closes #171 