### PR TITLE
fix: improve mobile styling for liquidity page buttons and tables

### DIFF
--- a/libs/web/src/components/pages/liquidity-page/components/Pools/MobilePools/MobilePoolItem/MobilePoolItem.tsx
+++ b/libs/web/src/components/pages/liquidity-page/components/Pools/MobilePools/MobilePoolItem/MobilePoolItem.tsx
@@ -65,7 +65,12 @@ const MobilePoolItem = ({poolData}: Props) => {
           {poolDescription}
         </p>
       </div>
-      <ActionButton variant="secondary" onClick={handleAddClick} fullWidth>
+      <ActionButton
+        variant="secondary"
+        onClick={handleAddClick}
+        fullWidth
+        size={"big"}
+      >
         Add Liquidity
       </ActionButton>
     </div>

--- a/libs/web/src/components/pages/liquidity-page/components/Pools/MobilePools/MobilePools.module.css
+++ b/libs/web/src/components/pages/liquidity-page/components/Pools/MobilePools/MobilePools.module.css
@@ -2,8 +2,9 @@
   display: flex;
   flex-direction: column;
   padding: 16px;
-  border-radius: 8px;
-  background-color: var(--background-grey-dark);
+  border-radius: 16px;
+  border: 11px solid var(--background-tertiary);
+  background-color: var(--background-secondary);
 }
 
 .separator {

--- a/libs/web/src/components/pages/liquidity-page/components/Positions/MobilePositions/MobilePositionItem/MobilePositionItem.tsx
+++ b/libs/web/src/components/pages/liquidity-page/components/Positions/MobilePositions/MobilePositionItem/MobilePositionItem.tsx
@@ -111,8 +111,7 @@ const MobilePositionItem = ({position, onClick}: Props) => {
           <p className={clsx(styles.poolDescription, "mc-mono-m")}>{feeText}</p>
         </div>
       </div>
-
-      <ActionButton onClick={onClick} variant="secondary" fullWidth>
+      <ActionButton onClick={onClick} variant="secondary" size="big" fullWidth>
         Manage Position
       </ActionButton>
     </div>

--- a/libs/web/src/components/pages/liquidity-page/components/Positions/MobilePositions/MobilePositions.module.css
+++ b/libs/web/src/components/pages/liquidity-page/components/Positions/MobilePositions/MobilePositions.module.css
@@ -3,7 +3,8 @@
   flex-direction: column;
   padding: 16px;
   border-radius: 16px;
-  background-color: var(--background-grey-dark);
+  border: 11px solid var(--background-tertiary);
+  background-color: var(--background-secondary);
 }
 
 .separator {


### PR DESCRIPTION
closes #172 

- The add liquidity and manage position button style was fixed, the button now has the same dimensions as the swap Action button on mobile view.

- The border and background color of tables in mobile view were fixed to match the desktop view