### PR TITLE
fix: modified alignment of slippage modal on smaller screens

### DIFF
--- a/libs/web/src/components/common/Swap/components/SettingsModalContent/SettingsModalContent.module.css
+++ b/libs/web/src/components/common/Swap/components/SettingsModalContent/SettingsModalContent.module.css
@@ -109,3 +109,9 @@
   color: var(--mc-black);
   pointer-events: none;
 }
+
+@media (max-width: 640px) {
+  .inputWrapper {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
Input box is now vertically aligned on smaller screens, scrollbar is avoided

<img width="330" alt="Screenshot 2025-05-15 at 2 23 04 PM" src="https://github.com/user-attachments/assets/b248bf87-db88-4efb-bc90-bc057874f78a" />

closes https://github.com/athulp8457/mira-amm-web/issues/158
