### PR TITLE
fix: removed legacy implementation of Header component

### DIFF
--- a/libs/web/src/components/pages/add-liquidity-page/AddLiquidityPageLayout.tsx
+++ b/libs/web/src/components/pages/add-liquidity-page/AddLiquidityPageLayout.tsx
@@ -28,7 +28,6 @@ const AddLiquidityPageLayout = () => {
 
   return (
     <>
-      <Header />
       <main className="action-layout" ref={mainRef}>
         <AddLiquidity poolId={poolId} poolKey={poolKey || ""} />
       </main>

--- a/libs/web/src/components/pages/landing-page/LandingPageLayout.tsx
+++ b/libs/web/src/components/pages/landing-page/LandingPageLayout.tsx
@@ -30,7 +30,6 @@ import RoadmapMobile from "../../icons/Roadmap/RoadmapMobileIcon";
 const LandingPageLayout = () => {
   return (
     <>
-      <Header isHomePage />
       <main className={clsx("mobileOnly", styles.main)}>
         <section className={styles.topBlock}>
           <h1>The Liquidity Hub on Fuel</h1>

--- a/libs/web/src/components/pages/remove-liquidity-page/index.tsx
+++ b/libs/web/src/components/pages/remove-liquidity-page/index.tsx
@@ -30,7 +30,6 @@ const RemoveLiquidityPageLayout = () => {
 
   return (
     <>
-      <Header />
       <main className="action-layout" ref={mainRef}>
         <RemoveLiquidity poolId={poolId} />
       </main>


### PR DESCRIPTION
add liquidity, remove liquidity and now unused landing page components had individual Header components included, caused duplication of Header.

closes https://github.com/athulp8457/mira-amm-web/issues/217